### PR TITLE
solrizer calling non-existant method in rsolr::client

### DIFF
--- a/bin/solrizer
+++ b/bin/solrizer
@@ -76,13 +76,13 @@ begin
   @clientid = "fedora_stomper"
   @destination = options[:destination]
 
-
-  $stderr.print "Connecting to stomp://#{@host}:#{@port} as #{@user}\n"
-  @conn = Stomp::Connection.open(@user, @password, @host, @port, @reliable, 5, {"client-id" => @clientid} )
-  $stderr.print "Getting output from #{@destination}\n"
-  
-  @conn.subscribe(@destination, {"activemq.subscriptionName" => @clientid, :ack =>"client" })
   while true
+      $stderr.print "Connecting to stomp://#{@host}:#{@port} as #{@user}\n"
+      @conn = Stomp::Connection.open(@user, @password, @host, @port, @reliable, 5, {"client-id" => @clientid} )
+      $stderr.print "Getting output from #{@destination}\n"
+  
+      @conn.subscribe(@destination, {"activemq.subscriptionName" => @clientid, :ack =>"client" })
+      #while true
       @msg = @conn.receive
       pid = @msg.headers["pid"]
       method = @msg.headers["methodName"]
@@ -99,8 +99,11 @@ begin
       end
       puts  "updated solr index for #{@msg.headers["pid"]}\n"
       @conn.ack @msg.headers["message-id"]
+      @conn.join
+      @conn.close
+      sleep 20
   end
-  @conn.join
+  #@conn.join
 
 rescue Exception => e
 p e


### PR DESCRIPTION
Hi -- I came across a problem with solrizer where if the method="purgeObject" ActiveFedora::SolrService.instance.conn.delete(pid) in bin/solrizer was raising #<TypeError: can't convert Symbol into Integer> and so I looked at RSolr::Client and changed the previous line to conn.delete_by_id(pid) and that fixes the problem.  It's only a couple character change but thought it may be useful for others.
