### PR TITLE
 Updating .format_node_value to handle dates

### DIFF
--- a/lib/solrizer/extractor.rb
+++ b/lib/solrizer/extractor.rb
@@ -29,14 +29,20 @@ class Extractor
   # Strips the majority of whitespace from the values array and then joins them with a single blank delimitter
   # Returns an empty string if values argument is nil
   #
-  # @param [Array] values Array of strings representing the values to be formatted
+  # @param [Array] values Array of strings or dates representing the values to be formatted
   # @return [String] 
   def self.format_node_value values
     if values.nil?
       return ""
     else
       values = [values] unless values.respond_to? :map
-      return values.map{|val| val.gsub(/\s+/,' ').strip}.join(" ")
+      return values.map { |val|
+        if val.is_a?(Date)
+          val.to_time.utc.iso8601.to_s
+        else
+          val.gsub(/\s+/,' ').strip
+        end
+      }.join(" ")
     end
   end
   

--- a/spec/units/extractor_spec.rb
+++ b/spec/units/extractor_spec.rb
@@ -18,6 +18,11 @@ describe Solrizer::Extractor do
     it "should strip white space out of a string" do
       Solrizer::Extractor.format_node_value("raw  string\n with whitespace").should == "raw string with whitespace"
     end
+
+    it 'should handle date fields' do
+      date = Date.civil(2011,12,01)
+      Solrizer::Extractor.format_node_value(date).should == date.to_time.utc.iso8601.to_s
+    end
   end
 
   describe "#insert_solr_field_value" do


### PR DESCRIPTION
The Problem:

In working with Sufia 0.0.7, when I go to upload a file, I encounter
the following exception:

```
undefined method `gsub' for Mon, 21 Jan 2013:Date
```

What appears to be the case is that the RDF Datastream declares the
:date_uploaded field as type :date. Then, when calling #to_solr,
the original solrizer is expecting to format strings, but ActiveFedora
is passing a Date value for the :date_uploaded's value

One of these systems should handle this, and I believe Solrizer should
properly transform values to their correct format.
