### PR TITLE
Added date to default descriptors for backward compatibility

### DIFF
--- a/lib/solrizer/default_descriptors.rb
+++ b/lib/solrizer/default_descriptors.rb
@@ -34,6 +34,11 @@ module Solrizer
       @symbol ||= Descriptor.new(:string, :stored, :indexed, :multivalued)
     end
 
+    # Solrizer 2.x compatibility; should probably be deprecated
+    def self.date
+      self.dateable
+    end
+
     # The suffix produced depends on the type parameter -- produces suffixes:
     #  _tei - for text fields
     #  _si - for strings 

--- a/spec/units/solrizer_spec.rb
+++ b/spec/units/solrizer_spec.rb
@@ -53,6 +53,8 @@ describe Solrizer do
     it "should delegate to default_field_mapper" do
         Solrizer.solr_name('foo', type: :string).should == "foo_tesim"
         Solrizer.solr_name('foo', :sortable).should == "foo_si"
+        Solrizer.solr_name('foo', :date).should == "foo_dtsim"
+        Solrizer.solr_name('foo', :symbol).should == "foo_ssim"
     end
   end
 end


### PR DESCRIPTION
Per recent discussion on hydra-tech about hydra-head 6.0.0 release and backward compatibility of solr_name.
