### PR TITLE
Remove dependency on solrizer-fedora, use AF to update index by pid.

### DIFF
--- a/bin/solrizer
+++ b/bin/solrizer
@@ -90,8 +90,7 @@ begin
       puts @msg.headers.inspect
       puts "\nPID: #{@msg.headers["pid"]}\n"
       if ["addDatastream", "addRelationship","ingest","modifyDatastreamByValue","modifyDatastreamByReference","modifyObject","purgeDatastream","purgeRelationship"].include? method
-        solrizer = Solrizer::Fedora::Solrizer.new
-        solrizer.solrize @msg.headers["pid"]
+        ActiveFedora::Base.find(@msg.headers["pid"], cast: true).update_index
       elsif method == "purgeObject"
         ActiveFedora::SolrService.instance.conn.delete_by_id(pid)
       else


### PR DESCRIPTION
There doesn't seem to be a version of solrizer-fedora compatible with solrizer 3, but I'm not sure its necessary to update that gem for compatibly with solrizer as it seems like this dependency can be replaced with a call to AF's update_index method.
