### PR TITLE
Allow any field_value except nil to be inserted into a solr field.  Closes #25

### DIFF
--- a/lib/solrizer/field_mapper.rb
+++ b/lib/solrizer/field_mapper.rb
@@ -181,7 +181,7 @@ module Solrizer
     # mapped names and values. The values in the hash are _arrays_, and may contain multiple values.
     
     def solr_names_and_values(field_name, field_value, index_types)
-      return {} unless field_value
+      return {} if field_value.nil?
       
       # Determine the set of index types
       index_types = Array(index_types)

--- a/spec/units/solrizer_spec.rb
+++ b/spec/units/solrizer_spec.rb
@@ -25,14 +25,23 @@ describe Solrizer do
         Solrizer.insert_field(doc, 'foo', Time.parse('2013-01-13T22:45:56+06:00'))
         doc.should == {'foo_dtsim' => ["2013-01-13T16:45:56Z"]}
       end
-      it "should insert Booleans" do
+      it "should insert true Booleans" do
         Solrizer.insert_field(doc, 'foo', true)
         doc.should == {'foo_bsi' => true}
+      end
+      it "should insert false Booleans" do
+        Solrizer.insert_field(doc, 'foo', false)
+        doc.should == {'foo_bsi' => false}
       end
 
       it "should insert multiple values" do
         Solrizer.insert_field(doc, 'foo', ['A name', 'B name'], :sortable, :facetable)
         doc.should == {'foo_si' => 'B name', 'foo_sim' => ['A name', 'B name']}
+      end
+
+      it 'should insert nothing when passed a nil value' do
+        Solrizer.insert_field(doc, 'foo', nil, :sortable, :facetable)
+        doc.should == {}
       end
     end
 


### PR DESCRIPTION
Solrizer will now be able to create boolean fields whose value is false.  Previously, only boolean fields with true were capable of being inserted into a solr_doc Hash.
