### PR TITLE
Use HTTPS URLs for RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec
 

--- a/History.txt
+++ b/History.txt
@@ -1,3 +1,5 @@
+  * 2014-09-10: Use HTTPS URLs for RubyGems [Michael Slone]
+
 h2. 3.3.0
   * 2014-07-17: Remove dependency on mediashelf-loggable [Justin Coyne]
   * 2014-07-17: Fix rspec deprecations [Justin Coyne]

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ fedora repository and writing to a solr instance.
 
 ## Installation
 
-The gem is hosted on [rubygems.org](http://rubygems.org/gems/solrizer). The best way to manage the gems for your project
+The gem is hosted on [rubygems.org](https://rubygems.org/gems/solrizer). The best way to manage the gems for your project
 is to use bundler.  Create a Gemfile in the root of your application and include the following:
 
 
-    source "http://rubygems.org"
+    source "https://rubygems.org"
     gem 'solrizer'
 
 Then:

--- a/gemfiles/gemfile.rails3
+++ b/gemfiles/gemfile.rails3
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec :path=>"../"
 

--- a/gemfiles/gemfile.rails4
+++ b/gemfiles/gemfile.rails4
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec :path=>"../"
 

--- a/solrizer.gemspec
+++ b/solrizer.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "stomp"
   s.add_dependency "daemons"
   s.add_dependency "activesupport"
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', '~> 2.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'yard'
   s.add_development_dependency 'RedCloth' # yard depends on redcloth


### PR DESCRIPTION
This modifies Gemfiles to use HTTPS URLs for RubyGems.

As a minor additional change, solrizer.gemspec now requires RSpec2, because the code

``` ruby
  RSpec::Core::RakeTask.new(:rspec) do |spec|
    spec.pattern = FileList['spec/**/*_spec.rb']
  end
```

does not function properly in RSpec3 (running rake yields the error "TypeError: no implicit conversion of Rake::FileList into String").
